### PR TITLE
Add simple Expo alarm clock app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+.expo/
+.DS_Store

--- a/App.js
+++ b/App.js
@@ -1,0 +1,54 @@
+import React, { useState, useEffect } from 'react';
+import { View, Button, Text, Platform } from 'react-native';
+import * as Notifications from 'expo-notifications';
+import DateTimePicker from '@react-native-community/datetimepicker';
+
+export default function App() {
+  const [time, setTime] = useState(new Date());
+  const [showPicker, setShowPicker] = useState(false);
+
+  useEffect(() => {
+    Notifications.requestPermissionsAsync();
+  }, []);
+
+  const scheduleAlarm = async () => {
+    const now = new Date();
+    const alarmTime = new Date(time);
+    if (alarmTime <= now) {
+      alarmTime.setDate(alarmTime.getDate() + 1);
+    }
+
+    await Notifications.scheduleNotificationAsync({
+      content: {
+        title: 'Alarm',
+        body: 'Wake up!',
+      },
+      trigger: alarmTime,
+    });
+  };
+
+  const onTimeChange = (_event, selectedDate) => {
+    const currentDate = selectedDate || time;
+    setShowPicker(Platform.OS === 'ios');
+    setTime(currentDate);
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Button title="Wybierz godzinę" onPress={() => setShowPicker(true)} />
+      {showPicker && (
+        <DateTimePicker
+          value={time}
+          mode="time"
+          is24Hour={true}
+          display="default"
+          onChange={onTimeChange}
+        />
+      )}
+      <Text style={{ marginVertical: 20 }}>
+        Budzik ustawiony na: {time.toLocaleTimeString()}
+      </Text>
+      <Button title="Ustaw budzik" onPress={scheduleAlarm} />
+    </View>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# Projekt-Budzika_w69988
-Projekt Programowanie Urządzeń Mobilnych 
+# Projekt Budzika
+
+Prosta aplikacja budzika napisana w React Native z wykorzystaniem Expo. 
+
+## Uruchamianie
+1. Zainstaluj zależności:
+   ```bash
+   npm install
+   ```
+2. Uruchom aplikację w Expo:
+   ```bash
+   npm start
+   ```
+
+Aplikacja pozwala ustawić godzinę budzika i używa powiadomień lokalnych do 
+przypomnienia o zadanym czasie.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "Budzik",
+    "slug": "budzik",
+    "version": "1.0.0",
+    "sdkVersion": "53.0.0",
+    "platforms": ["ios", "android"],
+    "entryPoint": "./App.js"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "budzik",
+  "version": "1.0.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "^53.0.17",
+    "expo-notifications": "~0.20.1",
+    "react": "18.2.0",
+    "react-native": "0.73.0",
+    "@react-native-community/datetimepicker": "6.7.3"
+  }
+}


### PR DESCRIPTION
## Summary
- add React Native expo files with simple alarm functionality
- document how to install and run the app
- add .gitignore

## Testing
- `npm install --ignore-scripts`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686986ab898c832baf9160acd1d9c961